### PR TITLE
Fix Magma Furnace name on GUI

### DIFF
--- a/src/main/java/rubedo/tileentity/TileEntityMagmaFurnace.java
+++ b/src/main/java/rubedo/tileentity/TileEntityMagmaFurnace.java
@@ -47,7 +47,7 @@ public class TileEntityMagmaFurnace extends TileEntityInventory implements
 
 	@Override
 	public String getInventoryName() {
-		return "rubedo.blocks.magma_furnace";
+		return "tile.magma_furnace.name";
 	}
 
 	private void updateMeta(Block block, int meta) {


### PR DESCRIPTION
https://github.com/Katalliaan/Rubedo/commit/00fa9fd3f29df9bdc82fbe54f325e2f70b354b47 changed the block name, but the TileEntity was still using the old one.